### PR TITLE
Create roles and permisions for users

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,8 @@ gem 'jquery-rails'
 
 # Use postgresql as the database for Active Record
 gem 'pg', '>= 0.18', '< 2.0'
+# authorizations and roles for employees
+gem 'pundit'
 # Use Puma as the app server
 gem 'puma', '~> 3.11'
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -159,6 +159,8 @@ GEM
     psych (3.1.0)
     public_suffix (3.0.3)
     puma (3.12.1)
+    pundit (2.0.1)
+      activesupport (>= 3.0.0)
     rack (2.0.6)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
@@ -319,6 +321,7 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.2)
   pg (>= 0.18, < 2.0)
   puma (~> 3.11)
+  pundit
   rails (~> 5.2.2)
   rails-controller-testing
   rspec-rails (~> 3.8)

--- a/app/assets/stylesheets/employees.scss
+++ b/app/assets/stylesheets/employees.scss
@@ -12,4 +12,8 @@
     justify-content: space-between;
     align-items: baseline;
   }
+
+  .role-select > label {
+    padding-right: 10px;
+  }
 }

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -1,5 +1,6 @@
 class CategoriesController < ApplicationController
   before_action :authenticate_company!
+  before_action :authenticate_admin!
   before_action :find_category, except: %i[index new create]
 
   def index

--- a/app/controllers/employees_controller.rb
+++ b/app/controllers/employees_controller.rb
@@ -1,5 +1,6 @@
 class EmployeesController < ApplicationController
   before_action :authenticate_company!
+  before_action :authenticate_admin!
   before_action :find_employee, except: %i[index new create]
 
   def index
@@ -40,7 +41,7 @@ class EmployeesController < ApplicationController
   def employee_params
     params.require(:employee).permit(:names, :last_names, :phone, :address, :state, :city,
                                      :identification, :password, :birthday, :start_date,
-                                     :email)
+                                     :email, :role)
   end
 
   def find_employee

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,5 +1,6 @@
 class ProductsController < ApplicationController
   before_action :authenticate_company!
+  before_action :authenticate_admin!
   before_action :find_product, except: %i[new create index]
 
   def index

--- a/app/controllers/suppliers_controller.rb
+++ b/app/controllers/suppliers_controller.rb
@@ -1,5 +1,6 @@
 class SuppliersController < ApplicationController
   before_action :authenticate_company!
+  before_action :authenticate_admin!
   before_action :find_supplier, except: %i[new create index]
 
   def index

--- a/app/models/employee.rb
+++ b/app/models/employee.rb
@@ -15,6 +15,7 @@
 #  start_date     :date
 #  password       :binary
 #  company_id     :bigint(8)
+#  role           :integer          default("delivery")
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
 #
@@ -22,10 +23,12 @@
 class Employee < ApplicationRecord
   belongs_to :company
 
-  validates :last_names, :names, :phone, :identification, presence: true
+  validates :last_names, :names, :phone, :identification, :role, presence: true
   validates :password, presence: true, uniqueness: { scope: :company_id }
 
   before_validation :encrypt_password
+
+  enum role: %i[delivery cashman waiter chef admin]
 
   def encrypt_password
     self.password = Digest::SHA256.digest password if password

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -1,0 +1,13 @@
+# Pundit, used for authorizations for employees roles
+class ApplicationPolicy
+  attr_reader :employee, :resource
+
+  def initialize(employee, resource)
+    @employee = employee
+    @resource = resource
+  end
+
+  def admin?
+    @employee.admin?
+  end
+end

--- a/app/policies/employee_policy.rb
+++ b/app/policies/employee_policy.rb
@@ -1,0 +1,3 @@
+# Pundit policies
+class EmployeePolicy < ApplicationPolicy
+end

--- a/app/views/employees/_form.html.erb
+++ b/app/views/employees/_form.html.erb
@@ -37,6 +37,11 @@
         <div class="form-group">
           <%= f.text_field :city, class: "form-control", placeholder: "Ciudad" %>
         </div>
+
+        <div class="form-group role-select">
+          <%= f.label 'Role' %>
+          <%= f.select :role, Employee.roles.keys.map { |w| [w.humanize, w] }, {}, class: "form-control" %>
+        </div>
       </div>
       <div class="col-md-6">
         <div class="form-group">

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -7,7 +7,7 @@
 
     <div class="collapse navbar-collapse" id="navbarSupportedContent">
       <ul class="navbar-nav mr-auto">
-        <% if current_company %>
+        <% if current_company && current_employee && policy(current_employee).admin? %>
           <li class="nav-item dropdown">
             <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"">
               Inventarios

--- a/db/migrate/20190409152205_create_employees.rb
+++ b/db/migrate/20190409152205_create_employees.rb
@@ -13,6 +13,7 @@ class CreateEmployees < ActiveRecord::Migration[5.2]
       t.date :start_date
       t.binary :password
       t.references :company, foreign_key: true
+      t.integer :role, default: 0
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -52,6 +52,7 @@ ActiveRecord::Schema.define(version: 2019_04_09_152205) do
     t.date "start_date"
     t.binary "password"
     t.bigint "company_id"
+    t.integer "role", default: 0
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["company_id"], name: "index_employees_on_company_id"

--- a/spec/factories/employees.rb
+++ b/spec/factories/employees.rb
@@ -15,6 +15,7 @@
 #  start_date     :date
 #  password       :binary
 #  company_id     :bigint(8)
+#  role           :integer          default("delivery")
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
 #
@@ -32,6 +33,7 @@ FactoryBot.define do
     birthday { Faker::Date.between(60.years.ago, 18.years.ago) }
     start_date { Faker::Date.between(1.years.ago, Date.today) }
     password { Faker::Number.unique.number(5) }
+
     company
   end
 end

--- a/spec/features/authentication/create_authenticate_employee_spec.rb
+++ b/spec/features/authentication/create_authenticate_employee_spec.rb
@@ -2,11 +2,21 @@ require 'rails_helper'
 
 describe 'Employee signin process', type: :feature, js: true do
   let!(:company) { create(:company) }
-  let!(:employee) { create(:employee, company: company, password: '1234') }
-  before { sign_in company }
+  let!(:employee) { create(:employee, company: company, password: '1234', role: 'admin') }
+
+  before do
+    sign_in company
+  end
 
   it 'create and login employee flow' do
     visit '/'
+
+    click_link 'Empleado'
+    expect(page).to have_current_path(new_employees_session_path)
+
+    fill_in 'password', with: '1234'
+
+    click_button 'Entrar'
     click_link 'Empleados'
     click_link 'Crear empleado'
 
@@ -44,8 +54,8 @@ describe 'Employee signin process', type: :feature, js: true do
     end
     expect(page).to have_current_path(employee_path(Employee.last))
 
+    click_link "Salir #{employee.names}"
     click_link 'Empleado'
-    expect(page).to have_current_path(new_employees_session_path)
 
     within('form') do
       fill_in 'password', with: 'Dont let to write letters'

--- a/spec/models/employee_spec.rb
+++ b/spec/models/employee_spec.rb
@@ -15,6 +15,7 @@
 #  start_date     :date
 #  password       :binary
 #  company_id     :bigint(8)
+#  role           :integer          default("delivery")
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
 #
@@ -32,6 +33,7 @@ RSpec.describe Employee, type: :model do
   it { should validate_presence_of(:phone) }
   it { should validate_presence_of(:identification) }
   it { should validate_presence_of(:password) }
+  it { should validate_presence_of(:role) }
 
   it 'should show uniqueness error' do
     employees = company.employees.new(password_duplicated_params)

--- a/spec/policies/employee_policy_spec.rb
+++ b/spec/policies/employee_policy_spec.rb
@@ -1,0 +1,4 @@
+require 'rails_helper'
+
+RSpec.describe EmployeePolicy, type: :policy do
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -45,8 +45,9 @@ Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 RSpec.configure do |config|
   config.include FactoryBot::Syntax::Methods
   config.include RequestSpecHelper
+  config.include EmployeeModule
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
-  config.fixture_path = "#{::Rails.root}/spec/fixtures"
+  # config.fixture_path = "#{::Rails.root}/spec/fixtures"
 
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false

--- a/spec/request/categories_spec.rb
+++ b/spec/request/categories_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Categories', type: :request do
-  describe 'company no logged' do
+  describe 'company not logged' do
     before { get '/categories' }
 
     it 'should redirect' do
@@ -17,87 +17,114 @@ RSpec.describe 'Categories', type: :request do
 
     before { sign_in company }
 
-    describe 'GET /categories' do
+    describe 'employee not logged' do
       before { get '/categories' }
-      it 'success' do
-        expect(response.status).to eq 200
-        expect(assigns(:categories).count).to eq 10
-      end
-    end
 
-    describe 'GET /categories/:id' do
-      before { get "/categories/#{category.id}" }
-
-      it 'success' do
-        expect(response.status).to eq 200
-        expect(assigns(:category)).to eq category
-      end
-    end
-
-    describe 'GET /categories/new' do
-      before { get '/categories/new' }
-
-      it 'success' do
-        expect(response.status).to eq 200
-      end
-    end
-
-    describe 'POST /category' do
-      context 'valid request' do
-        let!(:valid_attributes) { FactoryBot.attributes_for(:category) }
-        before { post '/categories', params: { category: valid_attributes } }
-
-        it 'success' do
-          expect(assigns(:category).persisted?).to be_truthy
-          expect(company.categories.count).to eq 11
-          expect(response.status).to eq 302
-        end
-      end
-
-      context 'invalid request' do
-        before { post '/categories', params: { category: { name: 'name' } } }
-
-        it 'fail' do
-          expect(assigns(:category).persisted?).to be_falsy
-          expect(company.categories.count).to eq 10
-          expect(response).to render_template(:new)
-        end
-      end
-    end
-    describe 'GET /categories/:id/edit' do
-      before { get "/categories/#{category.id}/edit" }
-
-      it 'success' do
-        expect(response.status).to eq 200
-      end
-    end
-
-    describe 'PUT /categories/:id' do
-      context 'valid attributes' do
-        before { put "/categories/#{category.id}", params: { category: { name: 'updated' } } }
-
-        it 'success' do
-          expect(category.reload.name).to eq 'updated'
-          expect(response.status).to eq 302
-        end
-      end
-
-      context 'invalid attributes' do
-        before { put "/categories/#{category.id}", params: { category: { name: '' } } }
-
-        it 'fail' do
-          expect(response.status).to eq 200
-          expect(response).to render_template(:edit)
-        end
-      end
-    end
-
-    describe 'DELETE /categories/:id' do
-      before { delete "/categories/#{category.id}" }
-
-      it 'success' do
+      it 'should redirect' do
         expect(response.status).to eq 302
-        expect(company.categories.count).to eq 9
+        expect(response).to redirect_to(new_employees_session_path)
+      end
+    end
+
+    describe 'employee logged without permissions' do
+      let!(:employee) { create(:employee, company: company, password: '1234', role: :chef) }
+
+      before { sign_in_employee }
+
+      it 'should redirect' do
+        expect(response.status).to eq 302
+        expect(response).to redirect_to root_path
+      end
+    end
+
+    describe 'employee logged with permissions' do
+      let!(:employee) { create(:employee, company: company, password: '1234', role: :admin) }
+
+      before { sign_in_employee }
+
+      describe 'GET /categories' do
+        before { get '/categories' }
+        it 'success' do
+          expect(response.status).to eq 200
+          expect(assigns(:categories).count).to eq 10
+        end
+      end
+
+      describe 'GET /categories/:id' do
+        before { get "/categories/#{category.id}" }
+
+        it 'success' do
+          expect(response.status).to eq 200
+          expect(assigns(:category)).to eq category
+        end
+      end
+
+      describe 'GET /categories/new' do
+        before { get '/categories/new' }
+
+        it 'success' do
+          expect(response.status).to eq 200
+        end
+      end
+
+      describe 'POST /category' do
+        context 'valid request' do
+          let!(:valid_attributes) { FactoryBot.attributes_for(:category) }
+          before { post '/categories', params: { category: valid_attributes } }
+
+          it 'success' do
+            expect(assigns(:category).persisted?).to be_truthy
+            expect(company.categories.count).to eq 11
+            expect(response.status).to eq 302
+          end
+        end
+
+        context 'invalid request' do
+          before { post '/categories', params: { category: { name: 'name' } } }
+
+          it 'fail' do
+            expect(assigns(:category).persisted?).to be_falsy
+            expect(company.categories.count).to eq 10
+            expect(response).to render_template(:new)
+          end
+        end
+      end
+
+      describe 'GET /categories/:id/edit' do
+        before { get "/categories/#{category.id}/edit" }
+
+        it 'success' do
+          expect(response.status).to eq 200
+        end
+      end
+
+      describe 'PUT /categories/:id' do
+        context 'valid attributes' do
+          before { put "/categories/#{category.id}", params: { category: { name: 'updated' } } }
+
+          it 'success' do
+            expect(category.reload.name).to eq 'updated'
+            expect(response.status).to eq 302
+          end
+        end
+
+        context 'invalid attributes' do
+          before { put "/categories/#{category.id}", params: { category: { name: '' } } }
+
+          it 'fail' do
+            expect(response.status).to eq 200
+            expect(response).to render_template(:edit)
+          end
+        end
+      end
+
+      describe 'DELETE /categories/:id' do
+        before { delete "/categories/#{category.id}" }
+
+        it 'success' do
+          expect(response.status).to eq 302
+          expect(company.categories.count).to eq 9
+        end
       end
     end
   end

--- a/spec/request/companies_spec.rb
+++ b/spec/request/companies_spec.rb
@@ -36,44 +36,61 @@ RSpec.describe 'Companies', type: :request do
         get '/companies'
       end
 
-      it 'should redirect' do
-        expect(response.status).to eq 302
+      describe 'employee logged without permissions' do
+        let!(:employee) { create(:employee, company: company, password: '1234', role: :chef) }
+
+        before { sign_in_employee }
+
+        it 'should redirect' do
+          expect(response.status).to eq 302
+          expect(response).to redirect_to root_path
+        end
+      end
+
+      describe 'employee logged with permissions' do
+        let!(:employee) { create(:employee, company: company, password: '1234', role: :admin) }
+
+        before { sign_in_employee }
+
+        it 'should redirect' do
+          expect(response.status).to eq 302
+        end
       end
     end
-  end
-  describe 'GET /companies/:id' do
-    let!(:company) { create(:company, user: user) }
+    describe 'GET /companies/:id' do
+      let!(:company) { create(:company, user: user) }
 
-    context 'user and company no authenticated' do
-      before { get "/companies/#{company.id}" }
+      context 'user and company no authenticated' do
+        before { get "/companies/#{company.id}" }
 
-      it 'redirect company login' do
-        expect(response.status).to eq 302
-        expect(response).to redirect_to new_company_session_path
-      end
-    end
-
-    context 'user authenticated' do
-      before do
-        sign_in user
-        get "/companies/#{company.id}"
+        it 'redirect company login' do
+          expect(response.status).to eq 302
+          expect(response).to redirect_to new_company_session_path
+        end
       end
 
-      it 'success' do
-        expect(assigns(:company)).to eq company
-        expect(response.status).to eq 200
-      end
-    end
+      context 'user authenticated' do
+        before do
+          sign_in user
+          get "/companies/#{company.id}"
+        end
 
-    context 'company authenticated' do
-      before do
-        sign_in company
-        get "/companies/#{company.id}"
+        it 'success' do
+          expect(assigns(:company)).to eq company
+          expect(response.status).to eq 200
+        end
       end
 
-      it 'success' do
-        expect(assigns(:company)).to eq company
-        expect(response.status).to eq 200
+      context 'company authenticated' do
+        before do
+          sign_in company
+          get "/companies/#{company.id}"
+        end
+
+        it 'success' do
+          expect(assigns(:company)).to eq company
+          expect(response.status).to eq 200
+        end
       end
     end
   end

--- a/spec/request/employees_spec.rb
+++ b/spec/request/employees_spec.rb
@@ -17,89 +17,106 @@ RSpec.describe 'Employees', type: :request do
 
     before { sign_in company }
 
-    describe 'GET employees' do
-      before { get '/employees' }
+    describe 'employee logged without permissions' do
+      let!(:employee) { create(:employee, company: company, password: '1234', role: :chef) }
 
-      it 'success' do
-        expect(response.status).to eq 200
-        expect(assigns(:employees).count).to eq 10
-      end
-    end
+      before { sign_in_employee }
 
-    describe 'GET employee' do
-      before { get "/employees/#{employee.id}" }
-
-      it 'success' do
-        expect(response.status).to eq 200
-        expect(assigns(:employee)).to eq employee
-      end
-    end
-
-    describe 'GET /employees/new' do
-      before { get '/employees/new' }
-
-      it 'success' do
-        expect(response.status).to eq 200
-      end
-    end
-
-    describe 'POST /employee' do
-      context 'valid request' do
-        let!(:valid_attributes) { FactoryBot.attributes_for(:employee) }
-        before { post '/employees', params: { employee: valid_attributes } }
-
-        it 'success' do
-          expect(assigns(:employee).persisted?).to be_truthy
-          expect(company.employees.count).to eq 11
-          expect(response.status).to eq 302
-        end
-      end
-
-      context 'invalid request' do
-        before { post '/employees', params: { employee: { name: 'name' } } }
-
-        it 'fail' do
-          expect(assigns(:employee).persisted?).to be_falsy
-          expect(company.employees.count).to eq 10
-          expect(response).to render_template(:new)
-        end
-
-      end
-    end
-    describe 'GET /employees/:id/edit' do
-      before { get "/employees/#{employee.id}/edit" }
-
-      it 'success' do
-        expect(response.status).to eq 200
-      end
-    end
-
-    describe 'PUT /employees/:id' do
-      context 'valid attributes' do
-        before { put "/employees/#{employee.id}", params: { employee: { names: 'updated' } } }
-
-        it 'success' do
-          expect(employee.reload.names).to eq 'updated'
-          expect(response.status).to eq 302
-        end
-      end
-
-      context 'invalid attributes' do
-        before { put "/employees/#{employee.id}", params: { employee: { names: '' } } }
-
-        it 'fail' do
-          expect(response.status).to eq 200
-          expect(response).to render_template(:edit)
-        end
-      end
-    end
-
-    describe 'DELETE /employees/:id' do
-      before { delete "/employees/#{employee.id}" }
-
-      it 'success' do
+      it 'should redirect' do
         expect(response.status).to eq 302
-        expect(company.employees.count).to eq 9
+        expect(response).to redirect_to root_path
+      end
+    end
+
+    describe 'employee logged with permissions' do
+      let!(:employee) { create(:employee, company: company, password: '1234', role: :admin) }
+
+      before { sign_in_employee }
+
+      describe 'GET employees' do
+        before { get '/employees' }
+
+        it 'success' do
+          expect(response.status).to eq 200
+          expect(assigns(:employees).count).to eq 10
+        end
+      end
+
+      describe 'GET employee' do
+        before { get "/employees/#{employee.id}" }
+
+        it 'success' do
+          expect(response.status).to eq 200
+          expect(assigns(:employee)).to eq employee
+        end
+      end
+
+      describe 'GET /employees/new' do
+        before { get '/employees/new' }
+
+        it 'success' do
+          expect(response.status).to eq 200
+        end
+      end
+
+      describe 'POST /employee' do
+        context 'valid request' do
+          let!(:valid_attributes) { FactoryBot.attributes_for(:employee) }
+          before { post '/employees', params: { employee: valid_attributes } }
+
+          it 'success' do
+            expect(assigns(:employee).persisted?).to be_truthy
+            expect(company.employees.count).to eq 11
+            expect(response.status).to eq 302
+          end
+        end
+
+        context 'invalid request' do
+          before { post '/employees', params: { employee: { name: 'name' } } }
+
+          it 'fail' do
+            expect(assigns(:employee).persisted?).to be_falsy
+            expect(company.employees.count).to eq 10
+            expect(response).to render_template(:new)
+          end
+
+        end
+      end
+      describe 'GET /employees/:id/edit' do
+        before { get "/employees/#{employee.id}/edit" }
+
+        it 'success' do
+          expect(response.status).to eq 200
+        end
+      end
+
+      describe 'PUT /employees/:id' do
+        context 'valid attributes' do
+          before { put "/employees/#{employee.id}", params: { employee: { names: 'updated' } } }
+
+          it 'success' do
+            expect(employee.reload.names).to eq 'updated'
+            expect(response.status).to eq 302
+          end
+        end
+
+        context 'invalid attributes' do
+          before { put "/employees/#{employee.id}", params: { employee: { names: '' } } }
+
+          it 'fail' do
+            expect(response.status).to eq 200
+            expect(response).to render_template(:edit)
+          end
+        end
+      end
+
+      describe 'DELETE /employees/:id' do
+        before { delete "/employees/#{employee.id}" }
+
+        it 'success' do
+          expect(response.status).to eq 302
+          expect(company.employees.count).to eq 9
+        end
       end
     end
   end

--- a/spec/request/products_spec.rb
+++ b/spec/request/products_spec.rb
@@ -21,88 +21,105 @@ RSpec.describe 'Products', type: :request do
 
     before { sign_in company }
 
-    describe 'GET /products' do
-      before { get '/products' }
-      it 'success' do
-        expect(response.status).to eq 200
-        expect(assigns(:products).count).to eq 10
-      end
-    end
+    describe 'employee logged without permissions' do
+      let!(:employee) { create(:employee, company: company, password: '1234', role: :chef) }
 
-    describe 'GET /products/:id' do
-      before { get "/products/#{product.id}" }
+      before { sign_in_employee }
 
-      it 'success' do
-        expect(response.status).to eq 200
-        expect(assigns(:product)).to eq product
-      end
-    end
-
-    describe 'GET /products/new' do
-      before { get '/products/new' }
-
-      it 'success' do
-        expect(response.status).to eq 200
-      end
-    end
-
-    describe 'POST /products' do
-      context 'valid request' do
-        let!(:associations) { { category_id: category.id, supplier_id: supplier.id } }
-        let!(:valid_attributes) { FactoryBot.attributes_for(:product) }
-        before { post '/products', params: { product: valid_attributes.merge(associations) } }
-
-        it 'success' do
-          expect(assigns(:product).persisted?).to be_truthy
-          expect(company.products.count).to eq 11
-          expect(response.status).to eq 302
-        end
-      end
-
-      context 'invalid request' do
-        before { post '/products', params: { product: { name: 'name' } } }
-
-        it 'fail' do
-          expect(assigns(:product).persisted?).to be_falsy
-          expect(company.products.count).to eq 10
-          expect(response).to render_template(:new)
-        end
-      end
-    end
-    describe 'GET /products/:id/edit' do
-      before { get "/products/#{product.id}/edit" }
-
-      it 'success' do
-        expect(response.status).to eq 200
-      end
-    end
-
-    describe 'PUT /products/:id' do
-      context 'valid attributes' do
-        before { put "/products/#{product.id}", params: { product: { name: 'updated' } } }
-
-        it 'success' do
-          expect(product.reload.name).to eq 'updated'
-          expect(response.status).to eq 302
-        end
-      end
-
-      context 'invalid attributes' do
-        before { put "/products/#{product.id}", params: { product: { name: '' } } }
-
-        it 'fail' do
-          expect(response.status).to eq 200
-          expect(response).to render_template(:edit)
-        end
-      end
-    end
-
-    describe 'DELETE /products/:id' do
-      before { delete "/products/#{product.id}" }
-
-      it 'success' do
+      it 'should redirect' do
         expect(response.status).to eq 302
-        expect(company.products.count).to eq 9
+        expect(response).to redirect_to root_path
+      end
+    end
+
+    describe 'employee logged with permissions' do
+      let!(:employee) { create(:employee, company: company, password: '1234', role: :admin) }
+
+      before { sign_in_employee }
+
+      describe 'GET /products' do
+        before { get '/products' }
+        it 'success' do
+          expect(response.status).to eq 200
+          expect(assigns(:products).count).to eq 10
+        end
+      end
+
+      describe 'GET /products/:id' do
+        before { get "/products/#{product.id}" }
+
+        it 'success' do
+          expect(response.status).to eq 200
+          expect(assigns(:product)).to eq product
+        end
+      end
+
+      describe 'GET /products/new' do
+        before { get '/products/new' }
+
+        it 'success' do
+          expect(response.status).to eq 200
+        end
+      end
+
+      describe 'POST /products' do
+        context 'valid request' do
+          let!(:associations) { { category_id: category.id, supplier_id: supplier.id } }
+          let!(:valid_attributes) { FactoryBot.attributes_for(:product) }
+          before { post '/products', params: { product: valid_attributes.merge(associations) } }
+
+          it 'success' do
+            expect(assigns(:product).persisted?).to be_truthy
+            expect(company.products.count).to eq 11
+            expect(response.status).to eq 302
+          end
+        end
+
+        context 'invalid request' do
+          before { post '/products', params: { product: { name: 'name' } } }
+
+          it 'fail' do
+            expect(assigns(:product).persisted?).to be_falsy
+            expect(company.products.count).to eq 10
+            expect(response).to render_template(:new)
+          end
+        end
+      end
+      describe 'GET /products/:id/edit' do
+        before { get "/products/#{product.id}/edit" }
+
+        it 'success' do
+          expect(response.status).to eq 200
+        end
+      end
+
+      describe 'PUT /products/:id' do
+        context 'valid attributes' do
+          before { put "/products/#{product.id}", params: { product: { name: 'updated' } } }
+
+          it 'success' do
+            expect(product.reload.name).to eq 'updated'
+            expect(response.status).to eq 302
+          end
+        end
+
+        context 'invalid attributes' do
+          before { put "/products/#{product.id}", params: { product: { name: '' } } }
+
+          it 'fail' do
+            expect(response.status).to eq 200
+            expect(response).to render_template(:edit)
+          end
+        end
+      end
+
+      describe 'DELETE /products/:id' do
+        before { delete "/products/#{product.id}" }
+
+        it 'success' do
+          expect(response.status).to eq 302
+          expect(company.products.count).to eq 9
+        end
       end
     end
   end

--- a/spec/request/suppliers_spec.rb
+++ b/spec/request/suppliers_spec.rb
@@ -17,88 +17,105 @@ RSpec.describe 'Suppliers', type: :request do
 
     before { sign_in company }
 
-    describe 'GET /suppliers' do
-      before { get '/suppliers' }
-      it 'success' do
-        expect(response.status).to eq 200
-        expect(assigns(:suppliers).count).to eq 10
-      end
-    end
+    describe 'employee logged without permissions' do
+      let!(:employee) { create(:employee, company: company, password: '1234', role: :chef) }
 
-    describe 'GET /suppliers/:id' do
+      before { sign_in_employee }
 
-      before { get "/suppliers/#{supplier.id}" }
-
-      it 'success' do
-        expect(response.status).to eq 200
-        expect(assigns(:supplier)).to eq supplier
-      end
-    end
-
-    describe 'GET /suppliers/new' do
-      before { get '/suppliers/new' }
-
-      it 'success' do
-        expect(response.status).to eq 200
-      end
-    end
-
-    describe 'POST /suppliers' do
-      context 'valid request' do
-        let!(:valid_attributes) { FactoryBot.attributes_for(:supplier) }
-        before { post '/suppliers', params: { supplier: valid_attributes } }
-
-        it 'success' do
-          expect(assigns(:supplier).persisted?).to be_truthy
-          expect(company.suppliers.count).to eq 11
-          expect(response.status).to eq 302
-        end
-      end
-
-      context 'invalid request' do
-        before { post '/suppliers', params: { supplier: { name: 'name' } } }
-
-        it 'fail' do
-          expect(assigns(:supplier).persisted?).to be_falsy
-          expect(company.suppliers.count).to eq 10
-          expect(response).to render_template(:new)
-        end
-      end
-    end
-    describe 'GET /suppliers/:id/edit' do
-      before { get "/suppliers/#{supplier.id}/edit" }
-
-      it 'success' do
-        expect(response.status).to eq 200
-      end
-    end
-
-    describe 'PUT /suppliers/:id' do
-      context 'valid attributes' do
-        before { put "/suppliers/#{supplier.id}", params: { supplier: { name: 'updated' } } }
-
-        it 'success' do
-          expect(supplier.reload.name).to eq 'updated'
-          expect(response.status).to eq 302
-        end
-      end
-
-      context 'invalid attributes' do
-        before { put "/suppliers/#{supplier.id}", params: { supplier: { name: '' } } }
-
-        it 'fail' do
-          expect(response.status).to eq 200
-          expect(response).to render_template(:edit)
-        end
-      end
-    end
-
-    describe 'DELETE /suppliers/:id' do
-      before { delete "/suppliers/#{supplier.id}" }
-
-      it 'success' do
+      it 'should redirect' do
         expect(response.status).to eq 302
-        expect(company.suppliers.count).to eq 9
+        expect(response).to redirect_to root_path
+      end
+    end
+
+    describe 'employee logged with permissions' do
+      let!(:employee) { create(:employee, company: company, password: '1234', role: :admin) }
+
+      before { sign_in_employee }
+
+      describe 'GET /suppliers' do
+        before { get '/suppliers' }
+        it 'success' do
+          expect(response.status).to eq 200
+          expect(assigns(:suppliers).count).to eq 10
+        end
+      end
+
+      describe 'GET /suppliers/:id' do
+
+        before { get "/suppliers/#{supplier.id}" }
+
+        it 'success' do
+          expect(response.status).to eq 200
+          expect(assigns(:supplier)).to eq supplier
+        end
+      end
+
+      describe 'GET /suppliers/new' do
+        before { get '/suppliers/new' }
+
+        it 'success' do
+          expect(response.status).to eq 200
+        end
+      end
+
+      describe 'POST /suppliers' do
+        context 'valid request' do
+          let!(:valid_attributes) { FactoryBot.attributes_for(:supplier) }
+          before { post '/suppliers', params: { supplier: valid_attributes } }
+
+          it 'success' do
+            expect(assigns(:supplier).persisted?).to be_truthy
+            expect(company.suppliers.count).to eq 11
+            expect(response.status).to eq 302
+          end
+        end
+
+        context 'invalid request' do
+          before { post '/suppliers', params: { supplier: { name: 'name' } } }
+
+          it 'fail' do
+            expect(assigns(:supplier).persisted?).to be_falsy
+            expect(company.suppliers.count).to eq 10
+            expect(response).to render_template(:new)
+          end
+        end
+      end
+      describe 'GET /suppliers/:id/edit' do
+        before { get "/suppliers/#{supplier.id}/edit" }
+
+        it 'success' do
+          expect(response.status).to eq 200
+        end
+      end
+
+      describe 'PUT /suppliers/:id' do
+        context 'valid attributes' do
+          before { put "/suppliers/#{supplier.id}", params: { supplier: { name: 'updated' } } }
+
+          it 'success' do
+            expect(supplier.reload.name).to eq 'updated'
+            expect(response.status).to eq 302
+          end
+        end
+
+        context 'invalid attributes' do
+          before { put "/suppliers/#{supplier.id}", params: { supplier: { name: '' } } }
+
+          it 'fail' do
+            expect(response.status).to eq 200
+            expect(response).to render_template(:edit)
+          end
+        end
+      end
+
+      describe 'DELETE /suppliers/:id' do
+        before { delete "/suppliers/#{supplier.id}" }
+
+        it 'success' do
+          expect(response.status).to eq 302
+          expect(company.suppliers.count).to eq 9
+        end
       end
     end
   end

--- a/spec/support/employee_authentication_helper.rb
+++ b/spec/support/employee_authentication_helper.rb
@@ -1,0 +1,5 @@
+module EmployeeModule
+  def sign_in_employee
+    post '/employees/sessions', params: { password: '1234' }
+  end
+end


### PR DESCRIPTION
In #16 we add a column to employees called roles, with a enum, and set the permision using pundit

closes #16